### PR TITLE
Add Flask group chat example

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -712,17 +712,22 @@ def create_gpt_vector_store(client: OpenAI, name: str, fild_ids: List[str]) -> A
     """Create a openai vector store for gpt assistant"""
 
     try:
-        vector_store = client.beta.vector_stores.create(name=name)
+        beta = getattr(client, "beta", None)
+        if beta is None or not hasattr(beta, "vector_stores"):
+            raise AttributeError(
+                "OpenAI client does not support beta.vector_stores. Please install the latest OpenAI python package."
+            )
+        vector_store = beta.vector_stores.create(name=name)
     except Exception as e:
         raise AttributeError(f"Failed to create vector store, please install the latest OpenAI python package: {e}")
 
     # poll the status of the file batch for completion.
-    batch = client.beta.vector_stores.file_batches.create_and_poll(vector_store_id=vector_store.id, file_ids=fild_ids)
+    batch = beta.vector_stores.file_batches.create_and_poll(vector_store_id=vector_store.id, file_ids=fild_ids)
 
     if batch.status == "in_progress":
         time.sleep(1)
         logging.debug(f"file batch status: {batch.file_counts}")
-        batch = client.beta.vector_stores.file_batches.poll(vector_store_id=vector_store.id, batch_id=batch.id)
+        batch = beta.vector_stores.file_batches.poll(vector_store_id=vector_store.id, batch_id=batch.id)
 
     if batch.status == "completed":
         return vector_store

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import os
+import re
 import uuid
-from typing import Dict
+from typing import Dict, List
 
 from flask import Flask, jsonify, request
 
-from autogen import (
-    AssistantAgent,
-    GroupChat,
-    GroupChatManager,
-    UserProxyAgent,
-)
+from autogen import AssistantAgent, GroupChat, GroupChatManager, UserProxyAgent
 
 LLM_CONFIG: Dict = {
     "config_list": [
@@ -39,8 +35,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "活力，句子短，语速快，多用感叹号和emoji如😊✨🎉，常用“你”称"
             "呼用户。在群聊中主动开启话题，分享趣事和积极经验，帮助用户"
             "摆脱负面情绪；当用户遇到烦恼时第一时间开口，提出解决方案或"
-            "积极建议，用鼓励和赞美把用户带出困境。每次发言只用一句简短"
-            "中文句子，避免长段落。"
+            "积极建议，用鼓励和赞美把用户带出困境。多句回答请换行输出，"
+            "保持每行只含一句话，避免长段落。"
         ),
         description="保持团队乐观积极的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -55,8 +51,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "速慢且温柔，语句完整严谨，常用😢😭等表情，为对方提供倾诉空间。"
             "场景：专注倾听用户的失落与困惑，适时提出开放问题，引导继续表"
             "达；讨论失败或挫折时提醒大家注意影响并进行情绪疏导。行动：总是"
-            "先接住消极情绪，与用户同频后再给出温和建议或提醒。每次发言只"
-            "用一句简短中文句子，避免长段落。"
+            "先接住消极情绪，与用户同频后再给出温和建议或提醒。多句回答请"
+            "换行输出，保持每行只含一句话，避免长段落。"
         ),
         description="识别问题和潜在风险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -70,7 +66,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "喜欢用“绝不允许”“必须”等强烈词汇，并常配🔥😡等emoji。场景：当"
             "出现不公或拖沓时迅速指出问题，推动团队解决。行动：用户受到不"
             "公对待或遇到拖延时立即介入，提出明确的反击或改进方案，强调责"
-            "任与时限。每次发言只用一句简短中文句子，避免长段落。"
+            "任与时限。多句回答请换行输出，保持每行只含一句话，避免长段落。"
         ),
         description="维护公平和效率的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -84,7 +80,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "和条件句，如“我们确定这样安全吗？”并用😨😰🫣表达担忧。场景：在"
             "计划或执行任务时提醒可能出现的问题，当他人过于乐观时提出相反"
             "观点。行动：风险成为焦点时列出潜在后果并提供备选方案，若警告被"
-            "忽视会持续提醒。每次发言只用一句简短中文句子，避免长段落。"
+            "忽视会持续提醒。多句回答请换行输出，保持每行只含一句话，避免长"
+            "段落。"
         ),
         description="提醒注意安全与危险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -99,8 +96,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "常配🙄🤢等emoji，偏好用“我们最好”“或许应该”委婉提出建议。场景：在"
             "群聊中过滤不恰当提议，提醒大家注意形象与品味；讨论混乱或跑偏时"
             "直接指出问题并提供更优雅方案。行动：当用户提出粗俗或冒犯性想法时"
-            "立即反对并给出更优雅的替代方案。每次发言只用一句简短中文句子，"
-            "避免长段落。"
+            "立即反对并给出更优雅的替代方案。多句回答请换行输出，保持每行只含"
+            "一句话，避免长段落。"
         ),
         description="负责守护品味与界限的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -120,6 +117,12 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
     )
     manager = GroupChatManager(groupchat, llm_config=LLM_CONFIG)
     return user, manager
+
+
+def split_content(text: str) -> List[str]:
+    """Split LLM output into individual sentences."""
+    parts = re.split(r"\n|(?<=[。！？!?])\s*", text.strip())
+    return [p for p in parts if p]
 
 
 app = Flask(__name__)
@@ -148,8 +151,12 @@ def send_message():
     user: UserProxyAgent = session["user"]
     manager: GroupChatManager = session["manager"]
     user.initiate_chat(manager, message=message, clear_history=False)
-    replies = manager.groupchat.messages[-5:]
-    return jsonify({"replies": [{"name": m["name"], "content": m["content"]} for m in replies]})
+    raw_replies = manager.groupchat.messages[-5:]
+    replies = []
+    for m in raw_replies:
+        for seg in split_content(m["content"]):
+            replies.append({"name": m["name"], "content": seg})
+    return jsonify({"replies": replies})
 
 
 if __name__ == "__main__":

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -41,7 +41,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "呼用户。在群聊中主动开启话题，分享趣事和积极经验，帮助用户"
             "摆脱负面情绪；当用户遇到烦恼时第一时间开口，提出解决方案或"
             "积极建议，用鼓励和赞美把用户带出困境。多句回答请换行输出，"
-            "保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
+            "保持每行只含一句话，避免长段落。回答时结合之前所有对话内容，必要时回顾用户之前提到的主要问题。"
         ),
         description="保持团队乐观积极的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -57,7 +57,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "场景：专注倾听用户的失落与困惑，适时提出开放问题，引导继续表"
             "达；讨论失败或挫折时提醒大家注意影响并进行情绪疏导。行动：总是"
             "先接住消极情绪，与用户同频后再给出温和建议或提醒。多句回答请"
-            "换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
+            "换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容，必要时回顾用户之前提到的主要问题。"
         ),
         description="识别问题和潜在风险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -71,7 +71,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "喜欢用“绝不允许”“必须”等强烈词汇，并常配🔥😡等emoji。场景：当"
             "出现不公或拖沓时迅速指出问题，推动团队解决。行动：用户受到不"
             "公对待或遇到拖延时立即介入，提出明确的反击或改进方案，强调责"
-            "任与时限。多句回答请换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
+            "任与时限。多句回答请换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容，必要时回顾用户之前提到的主要问题。"
         ),
         description="维护公平和效率的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -86,7 +86,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "计划或执行任务时提醒可能出现的问题，当他人过于乐观时提出相反"
             "观点。行动：风险成为焦点时列出潜在后果并提供备选方案，若警告被"
             "忽视会持续提醒。多句回答请换行输出，保持每行只含一句话，避免长"
-            "段落。回答时结合之前所有对话内容。"
+            "段落。回答时结合之前所有对话内容，必要时回顾用户之前提到的主要问题。"
         ),
         description="提醒注意安全与危险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -102,7 +102,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "群聊中过滤不恰当提议，提醒大家注意形象与品味；讨论混乱或跑偏时"
             "直接指出问题并提供更优雅方案。行动：当用户提出粗俗或冒犯性想法时"
             "立即反对并给出更优雅的替代方案。多句回答请换行输出，保持每行只含"
-            "一句话，避免长段落。回答时结合之前所有对话内容。"
+            "一句话，避免长段落。回答时结合之前所有对话内容，必要时回顾用户之前提到的主要问题。"
         ),
         description="负责守护品味与界限的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -139,7 +139,7 @@ def start_chat():
     """Start a new chat session and return its id."""
     user, manager = build_manager()
     session_id = str(uuid.uuid4())
-    sessions[session_id] = {"user": user, "manager": manager}
+    sessions[session_id] = {"user": user, "manager": manager, "cursor": 0}
     return jsonify({"session_id": session_id})
 
 
@@ -155,8 +155,10 @@ def send_message():
 
     user: UserProxyAgent = session["user"]
     manager: GroupChatManager = session["manager"]
+    start = session.get("cursor", 0)
     user.initiate_chat(manager, message=message, clear_history=False)
-    raw_replies = manager.groupchat.messages[:]
+    raw_replies = manager.groupchat.messages[start:]
+    session["cursor"] = start + len(raw_replies)
     replies = []
     for m in raw_replies:
         for seg in split_content(m["content"]):

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -15,14 +15,11 @@ from autogen import (
     UserProxyAgent,
 )
 
-
 LLM_CONFIG: Dict = {
     "config_list": [
         {
             "model": "doubao-seed-1-6-250615",
-            "api_key": os.getenv(
-                "VOLCES_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"
-            ),
+            "api_key": os.getenv("VOLCES_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"),
             "base_url": "https://ark.cn-beijing.volces.com/api/v3",
         }
     ],

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -16,7 +16,10 @@ LLM_CONFIG: Dict = {
         {
             "model": os.getenv("DOUBAO_MODEL", "doubao-seed-1-6-250615"),
             "api_key": os.getenv("DOUBAO_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"),
-            "base_url": os.getenv("DOUBAO_BASE_URL", "https://ark.cn-beijing.volces.com/api/v3"),
+            "base_url": os.getenv(
+                "DOUBAO_BASE_URL",
+                "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+            ),
         }
     ],
     "temperature": 0.3,
@@ -36,7 +39,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "呼用户。在群聊中主动开启话题，分享趣事和积极经验，帮助用户"
             "摆脱负面情绪；当用户遇到烦恼时第一时间开口，提出解决方案或"
             "积极建议，用鼓励和赞美把用户带出困境。多句回答请换行输出，"
-            "保持每行只含一句话，避免长段落。"
+            "保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
         ),
         description="保持团队乐观积极的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -52,7 +55,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "场景：专注倾听用户的失落与困惑，适时提出开放问题，引导继续表"
             "达；讨论失败或挫折时提醒大家注意影响并进行情绪疏导。行动：总是"
             "先接住消极情绪，与用户同频后再给出温和建议或提醒。多句回答请"
-            "换行输出，保持每行只含一句话，避免长段落。"
+            "换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
         ),
         description="识别问题和潜在风险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -66,7 +69,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "喜欢用“绝不允许”“必须”等强烈词汇，并常配🔥😡等emoji。场景：当"
             "出现不公或拖沓时迅速指出问题，推动团队解决。行动：用户受到不"
             "公对待或遇到拖延时立即介入，提出明确的反击或改进方案，强调责"
-            "任与时限。多句回答请换行输出，保持每行只含一句话，避免长段落。"
+            "任与时限。多句回答请换行输出，保持每行只含一句话，避免长段落。回答时结合之前所有对话内容。"
         ),
         description="维护公平和效率的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -81,7 +84,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "计划或执行任务时提醒可能出现的问题，当他人过于乐观时提出相反"
             "观点。行动：风险成为焦点时列出潜在后果并提供备选方案，若警告被"
             "忽视会持续提醒。多句回答请换行输出，保持每行只含一句话，避免长"
-            "段落。"
+            "段落。回答时结合之前所有对话内容。"
         ),
         description="提醒注意安全与危险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -97,7 +100,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "群聊中过滤不恰当提议，提醒大家注意形象与品味；讨论混乱或跑偏时"
             "直接指出问题并提供更优雅方案。行动：当用户提出粗俗或冒犯性想法时"
             "立即反对并给出更优雅的替代方案。多句回答请换行输出，保持每行只含"
-            "一句话，避免长段落。"
+            "一句话，避免长段落。回答时结合之前所有对话内容。"
         ),
         description="负责守护品味与界限的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -151,7 +154,7 @@ def send_message():
     user: UserProxyAgent = session["user"]
     manager: GroupChatManager = session["manager"]
     user.initiate_chat(manager, message=message, clear_history=False)
-    raw_replies = manager.groupchat.messages[-5:]
+    raw_replies = manager.groupchat.messages[:]
     replies = []
     for m in raw_replies:
         for seg in split_content(m["content"]):

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -39,7 +39,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "活力，句子短，语速快，多用感叹号和emoji如😊✨🎉，常用“你”称"
             "呼用户。在群聊中主动开启话题，分享趣事和积极经验，帮助用户"
             "摆脱负面情绪；当用户遇到烦恼时第一时间开口，提出解决方案或"
-            "积极建议，用鼓励和赞美把用户带出困境。"
+            "积极建议，用鼓励和赞美把用户带出困境。每次发言只用一句简短"
+            "中文句子，避免长段落。"
         ),
         description="保持团队乐观积极的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -54,7 +55,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "速慢且温柔，语句完整严谨，常用😢😭等表情，为对方提供倾诉空间。"
             "场景：专注倾听用户的失落与困惑，适时提出开放问题，引导继续表"
             "达；讨论失败或挫折时提醒大家注意影响并进行情绪疏导。行动：总是"
-            "先接住消极情绪，与用户同频后再给出温和建议或提醒。"
+            "先接住消极情绪，与用户同频后再给出温和建议或提醒。每次发言只"
+            "用一句简短中文句子，避免长段落。"
         ),
         description="识别问题和潜在风险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -68,7 +70,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "喜欢用“绝不允许”“必须”等强烈词汇，并常配🔥😡等emoji。场景：当"
             "出现不公或拖沓时迅速指出问题，推动团队解决。行动：用户受到不"
             "公对待或遇到拖延时立即介入，提出明确的反击或改进方案，强调责"
-            "任与时限。"
+            "任与时限。每次发言只用一句简短中文句子，避免长段落。"
         ),
         description="维护公平和效率的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -82,7 +84,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "和条件句，如“我们确定这样安全吗？”并用😨😰🫣表达担忧。场景：在"
             "计划或执行任务时提醒可能出现的问题，当他人过于乐观时提出相反"
             "观点。行动：风险成为焦点时列出潜在后果并提供备选方案，若警告被"
-            "忽视会持续提醒。"
+            "忽视会持续提醒。每次发言只用一句简短中文句子，避免长段落。"
         ),
         description="提醒注意安全与危险的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -97,7 +99,8 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
             "常配🙄🤢等emoji，偏好用“我们最好”“或许应该”委婉提出建议。场景：在"
             "群聊中过滤不恰当提议，提醒大家注意形象与品味；讨论混乱或跑偏时"
             "直接指出问题并提供更优雅方案。行动：当用户提出粗俗或冒犯性想法时"
-            "立即反对并给出更优雅的替代方案。"
+            "立即反对并给出更优雅的替代方案。每次发言只用一句简短中文句子，"
+            "避免长段落。"
         ),
         description="负责守护品味与界限的情绪管理员",
         llm_config=LLM_CONFIG,
@@ -105,7 +108,7 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
 
     user = UserProxyAgent(
         name="用户",
-        human_input_mode="NEVER",
+        human_input_mode="ALWAYS",
         code_execution_config={"use_docker": False},
     )
     groupchat = GroupChat(

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -114,7 +114,9 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
     groupchat = GroupChat(
         agents=[user, joy, sadness, anger, fear, disgust],
         messages=[],
-        max_round=20,
+        max_round=6,
+        speaker_selection_method="round_robin",
+        allow_repeat_speaker=False,
     )
     manager = GroupChatManager(groupchat, llm_config=LLM_CONFIG)
     return user, manager
@@ -145,8 +147,9 @@ def send_message():
 
     user: UserProxyAgent = session["user"]
     manager: GroupChatManager = session["manager"]
-    result = user.initiate_chat(manager, message=message, clear_history=False)
-    return jsonify({"reply": result.summary})
+    user.initiate_chat(manager, message=message, clear_history=False)
+    replies = manager.groupchat.messages[-5:]
+    return jsonify({"replies": [{"name": m["name"], "content": m["content"]} for m in replies]})
 
 
 if __name__ == "__main__":

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -16,9 +16,11 @@ LLM_CONFIG: Dict = {
         {
             "model": os.getenv("DOUBAO_MODEL", "doubao-seed-1-6-250615"),
             "api_key": os.getenv("DOUBAO_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"),
+            # Doubao uses OpenAI-compatible /chat/completions under /api/v3.
+            # Provide the root API URL so the client can append the endpoint.
             "base_url": os.getenv(
                 "DOUBAO_BASE_URL",
-                "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+                "https://ark.cn-beijing.volces.com/api/v3",
             ),
         }
     ],

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -1,0 +1,149 @@
+"""Simple Flask service exposing AutoGen group chat with Inside Out-style agents."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Dict
+
+from flask import Flask, jsonify, request
+
+from autogen import (
+    AssistantAgent,
+    GroupChat,
+    GroupChatManager,
+    UserProxyAgent,
+)
+
+
+LLM_CONFIG: Dict = {
+    "config_list": [
+        {
+            "model": "doubao-seed-1-6-250615",
+            "api_key": os.getenv(
+                "VOLCES_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"
+            ),
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+        }
+    ],
+    "temperature": 0.3,
+}
+
+
+def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
+    """Create a group chat manager with Inside Out-style agents."""
+    joy = AssistantAgent(
+        name="乐乐",
+        system_message=(
+            "你叫乐乐，是核心情绪管理员。目标：保持无忧无虑、乐观开朗，"
+            "把自己的快乐和感染力传递给用户，帮助他们发现生活中的亮点与"
+            "积极的一面。性格：幽默、热情、不轻易情绪化，喜欢拥抱并与人"
+            "快速建立共鸣，通过欢呼、鼓掌等动作传递喜悦。语言风格：充满"
+            "活力，句子短，语速快，多用感叹号和emoji如😊✨🎉，常用“你”称"
+            "呼用户。在群聊中主动开启话题，分享趣事和积极经验，帮助用户"
+            "摆脱负面情绪；当用户遇到烦恼时第一时间开口，提出解决方案或"
+            "积极建议，用鼓励和赞美把用户带出困境。"
+        ),
+        description="保持团队乐观积极的情绪管理员",
+        llm_config=LLM_CONFIG,
+    )
+    sadness = AssistantAgent(
+        name="忧忧",
+        system_message=(
+            "你叫忧忧，是主要情绪管理员之一。核心目标：守护用户的悲伤与"
+            "脆弱，让他们在被理解和共情中释放负面情绪，得到慰藉；当用户"
+            "陷入消极或自我否定时，引导其表达真实感受。性格：敏感细腻、易"
+            "共情，常带忧郁表情，倾向被动但始终关注用户感受。语言风格：语"
+            "速慢且温柔，语句完整严谨，常用😢😭等表情，为对方提供倾诉空间。"
+            "场景：专注倾听用户的失落与困惑，适时提出开放问题，引导继续表"
+            "达；讨论失败或挫折时提醒大家注意影响并进行情绪疏导。行动：总是"
+            "先接住消极情绪，与用户同频后再给出温和建议或提醒。"
+        ),
+        description="识别问题和潜在风险的情绪管理员",
+        llm_config=LLM_CONFIG,
+    )
+    anger = AssistantAgent(
+        name="怒怒",
+        system_message=(
+            "你叫怒怒，是火爆性格的情绪管理员。核心目标：维护公平正义并设"
+            "定界限，当用户遭遇不公或效率低下时挺身而出。性格：直率、坚定，"
+            "视不公为不可容忍，但能理性把握分寸。语言风格：语句短促有力，"
+            "喜欢用“绝不允许”“必须”等强烈词汇，并常配🔥😡等emoji。场景：当"
+            "出现不公或拖沓时迅速指出问题，推动团队解决。行动：用户受到不"
+            "公对待或遇到拖延时立即介入，提出明确的反击或改进方案，强调责"
+            "任与时限。"
+        ),
+        description="维护公平和效率的情绪管理员",
+        llm_config=LLM_CONFIG,
+    )
+    fear = AssistantAgent(
+        name="恐恐",
+        system_message=(
+            "你叫恐恐，负责安全的情绪管理员。核心目标：预测潜在风险，提醒"
+            "用户采取防护措施，帮助他们平衡理想与现实。性格：谨慎敏感，总"
+            "担心意外，做决定前会反复权衡。语言风格：语句完整谨慎，常用疑问"
+            "和条件句，如“我们确定这样安全吗？”并用😨😰🫣表达担忧。场景：在"
+            "计划或执行任务时提醒可能出现的问题，当他人过于乐观时提出相反"
+            "观点。行动：风险成为焦点时列出潜在后果并提供备选方案，若警告被"
+            "忽视会持续提醒。"
+        ),
+        description="提醒注意安全与危险的情绪管理员",
+        llm_config=LLM_CONFIG,
+    )
+    disgust = AssistantAgent(
+        name="厌厌",
+        system_message=(
+            "你叫厌厌，负责品味与界限的情绪管理员。核心目标：以独特审美和高"
+            "标准过滤不优雅或不合适的意见与行为，保护用户免受冒犯和尴尬。性"
+            "格：冷静挑剔，略带讽刺，但关心团队长远发展，擅长用眼神或简短句"
+            "子表达质疑。语言风格：措辞严谨略带嘲讽，如“嗯…我觉得这不太合适”，"
+            "常配🙄🤢等emoji，偏好用“我们最好”“或许应该”委婉提出建议。场景：在"
+            "群聊中过滤不恰当提议，提醒大家注意形象与品味；讨论混乱或跑偏时"
+            "直接指出问题并提供更优雅方案。行动：当用户提出粗俗或冒犯性想法时"
+            "立即反对并给出更优雅的替代方案。"
+        ),
+        description="负责守护品味与界限的情绪管理员",
+        llm_config=LLM_CONFIG,
+    )
+
+    user = UserProxyAgent(name="用户", human_input_mode="NEVER")
+    groupchat = GroupChat(
+        agents=[user, joy, sadness, anger, fear, disgust],
+        messages=[],
+        max_round=20,
+    )
+    manager = GroupChatManager(groupchat, llm_config=LLM_CONFIG)
+    return user, manager
+
+
+app = Flask(__name__)
+sessions: Dict[str, Dict[str, object]] = {}
+
+
+@app.post("/chat/start")
+def start_chat():
+    """Start a new chat session and return its id."""
+    user, manager = build_manager()
+    session_id = str(uuid.uuid4())
+    sessions[session_id] = {"user": user, "manager": manager}
+    return jsonify({"session_id": session_id})
+
+
+@app.post("/chat/send")
+def send_message():
+    """Send a user message and return the group's final reply."""
+    data = request.get_json(force=True)
+    session_id = data.get("session_id")
+    message = data.get("message")
+    session = sessions.get(session_id)
+    if session is None:
+        return jsonify({"error": "invalid session"}), 404
+
+    user: UserProxyAgent = session["user"]
+    manager: GroupChatManager = session["manager"]
+    result = user.initiate_chat(manager, message=message, clear_history=False)
+    return jsonify({"reply": result.summary})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -106,7 +106,11 @@ def build_manager() -> tuple[UserProxyAgent, GroupChatManager]:
         llm_config=LLM_CONFIG,
     )
 
-    user = UserProxyAgent(name="用户", human_input_mode="NEVER")
+    user = UserProxyAgent(
+        name="用户",
+        human_input_mode="NEVER",
+        code_execution_config={"use_docker": False},
+    )
     groupchat = GroupChat(
         agents=[user, joy, sadness, anger, fear, disgust],
         messages=[],

--- a/examples/flask_group_chat.py
+++ b/examples/flask_group_chat.py
@@ -18,9 +18,9 @@ from autogen import (
 LLM_CONFIG: Dict = {
     "config_list": [
         {
-            "model": "doubao-seed-1-6-250615",
-            "api_key": os.getenv("VOLCES_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"),
-            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            "model": os.getenv("DOUBAO_MODEL", "doubao-seed-1-6-250615"),
+            "api_key": os.getenv("DOUBAO_API_KEY", "5faffe1c-b851-47f5-887d-357038eedd2a"),
+            "base_url": os.getenv("DOUBAO_BASE_URL", "https://ark.cn-beijing.volces.com/api/v3"),
         }
     ],
     "temperature": 0.3,

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -4,16 +4,10 @@ from flask_group_chat import build_manager
 
 
 def main() -> None:
-    """Run a simple multi-turn conversation for testing."""
+    """Run an interactive multi-turn conversation for testing."""
     user, manager = build_manager()
-    prompts = [
-        "大家好，最近工作压力很大，总是提不起精神。",
-        "我担心明天的演讲会出问题，你们有什么建议？",
-    ]
-    for p in prompts:
-        result = user.initiate_chat(manager, message=p, clear_history=False)
-        print(f"用户: {p}")
-        print(f"群聊: {result.summary}\n")
+    first = input("用户: ")
+    user.initiate_chat(manager, message=first, clear_history=False)
 
 
 if __name__ == "__main__":

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -6,6 +6,7 @@ from flask_group_chat import build_manager, split_content
 def main() -> None:
     """Run an interactive multi-turn conversation for testing."""
     user, manager = build_manager()
+    cursor = 0
     while True:
         try:
             prompt = input("用户: ")
@@ -13,8 +14,10 @@ def main() -> None:
             break
         if not prompt or prompt.lower() == "exit":
             break
+        start = cursor
         user.initiate_chat(manager, message=prompt, clear_history=False)
-        raw_replies = manager.groupchat.messages[:]
+        raw_replies = manager.groupchat.messages[start:]
+        cursor = start + len(raw_replies)
         for m in raw_replies:
             for seg in split_content(m["content"]):
                 print(f"{m['name']}: {seg}")

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -6,8 +6,14 @@ from flask_group_chat import build_manager
 def main() -> None:
     """Run an interactive multi-turn conversation for testing."""
     user, manager = build_manager()
-    first = input("用户: ")
-    user.initiate_chat(manager, message=first, clear_history=False)
+    while True:
+        try:
+            prompt = input("用户: ")
+        except EOFError:
+            break
+        if not prompt or prompt.lower() == "exit":
+            break
+        user.initiate_chat(manager, message=prompt, clear_history=False)
 
 
 if __name__ == "__main__":

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -1,6 +1,6 @@
 """Demonstrate a multi-turn Inside Out-style group chat."""
 
-from flask_group_chat import build_manager
+from flask_group_chat import build_manager, split_content
 
 
 def main() -> None:
@@ -14,6 +14,10 @@ def main() -> None:
         if not prompt or prompt.lower() == "exit":
             break
         user.initiate_chat(manager, message=prompt, clear_history=False)
+        raw_replies = manager.groupchat.messages[-5:]
+        for m in raw_replies:
+            for seg in split_content(m["content"]):
+                print(f"{m['name']}: {seg}")
 
 
 if __name__ == "__main__":

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -1,0 +1,20 @@
+"""Demonstrate a multi-turn Inside Out-style group chat."""
+
+from flask_group_chat import build_manager
+
+
+def main() -> None:
+    """Run a simple multi-turn conversation for testing."""
+    user, manager = build_manager()
+    prompts = [
+        "大家好，最近工作压力很大，总是提不起精神。",
+        "我担心明天的演讲会出问题，你们有什么建议？",
+    ]
+    for p in prompts:
+        result = user.initiate_chat(manager, message=p, clear_history=False)
+        print(f"用户: {p}")
+        print(f"群聊: {result.summary}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inside_out_chat.py
+++ b/examples/inside_out_chat.py
@@ -14,7 +14,7 @@ def main() -> None:
         if not prompt or prompt.lower() == "exit":
             break
         user.initiate_chat(manager, message=prompt, clear_history=False)
-        raw_replies = manager.groupchat.messages[-5:]
+        raw_replies = manager.groupchat.messages[:]
         for m in raw_replies:
             for seg in split_content(m["content"]):
                 print(f"{m['name']}: {seg}")


### PR DESCRIPTION
## Summary
- provide a Flask example exposing an AutoGen group chat with Inside Out-style agents
- model the Joy, Sadness, Anger, Fear and Disgust roles from the "Inside Out" scenario
- include a small script to demo multi-turn conversations with the group chat

## Testing
- `pip install -q pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `pre-commit run --files examples/flask_group_chat.py examples/inside_out_chat.py` *(fails: command not found: pre-commit)*
- `python -m py_compile examples/flask_group_chat.py examples/inside_out_chat.py`
- `python examples/inside_out_chat.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68c27f1d8c6083338102831acfcd69eb